### PR TITLE
fix(mapeamento): implementa conversão customizada de request para ent…

### DIFF
--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/controller/ResidentController.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/controller/ResidentController.java
@@ -1,19 +1,20 @@
 package br.com.washingtonDDS.acesso_api.adapter.input.controller;
 
 import br.com.washingtonDDS.acesso_api.adapter.input.mapper.ResidentMapper;
-import br.com.washingtonDDS.acesso_api.adapter.input.mapper.UserMapper;
 import br.com.washingtonDDS.acesso_api.adapter.input.request.ResidentRequest;
 import br.com.washingtonDDS.acesso_api.adapter.input.request.ResidentResponseDto;
 import br.com.washingtonDDS.acesso_api.core.domain.model.Resident;
 import br.com.washingtonDDS.acesso_api.port.input.ResidentInputPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/residents")
 @RequiredArgsConstructor
 public class ResidentController {
+
 
     private final ResidentInputPort residentInputPort;
 
@@ -22,7 +23,7 @@ public class ResidentController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ResidentResponseDto create(@RequestBody ResidentRequest residentRequest) {
+    public ResidentResponseDto create(@Validated @RequestBody ResidentRequest residentRequest) {
         Resident resident = residentMapper.toDomainResident(residentRequest);
         Resident newResident = residentInputPort.create(resident);
         return residentMapper.toResidentResponseDto(newResident);

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/controller/UserController.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/controller/UserController.java
@@ -7,6 +7,7 @@ import br.com.washingtonDDS.acesso_api.core.domain.model.User;
 import br.com.washingtonDDS.acesso_api.port.input.UserInputPort;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,7 +22,7 @@ public class UserController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public UserResponseDto create(@RequestBody UserRequest userRequest){
+    public UserResponseDto create(@Validated @RequestBody UserRequest userRequest){
         User user = userMapper.toDomain(userRequest);
         User createdUser = userInputPort.create(user);
         return userMapper.toResponseDto(createdUser);

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/mapper/ResidentMapper.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/mapper/ResidentMapper.java
@@ -6,10 +6,13 @@ import br.com.washingtonDDS.acesso_api.adapter.input.request.ResidentResponseDto
 import br.com.washingtonDDS.acesso_api.adapter.output.entity.ResidentEntity;
 import br.com.washingtonDDS.acesso_api.core.domain.model.Resident;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface ResidentMapper {
+
+
 
     Resident toDomainResidentEntity(ResidentEntity residentEntity);
 
@@ -17,6 +20,7 @@ public interface ResidentMapper {
 
     ResidentResponseDto toResidentResponseDto(Resident resident);
 
+    @Mapping(target = "person", source = "person")
     ResidentEntity toEntityResident(Resident resident);
 
 }

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/mapper/UserMapper.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/mapper/UserMapper.java
@@ -6,7 +6,7 @@ import br.com.washingtonDDS.acesso_api.core.domain.model.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 
-@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, uses = {PersonMapper.class})
 public interface UserMapper {
 
     UserRequest toRequest( User user);

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/request/PersonRequest.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/request/PersonRequest.java
@@ -1,15 +1,6 @@
 package br.com.washingtonDDS.acesso_api.adapter.input.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Getter
-@Setter
-public class PersonRequest {
-    private Long id;
-    private String name;
+public record PersonRequest(String name) {
+
 }

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/request/ResidentRequest.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/request/ResidentRequest.java
@@ -1,62 +1,6 @@
 package br.com.washingtonDDS.acesso_api.adapter.input.request;
 
+
 import br.com.washingtonDDS.acesso_api.core.domain.model.Person;
 
-public class ResidentRequest {
-    private Long id;
-    private String cpf;
-    private String address;
-    private String phone;
-    private Person person;
-
-    public ResidentRequest() {
-    }
-
-    public ResidentRequest(Long id, String cpf, String address, String phone, Person person) {
-        this.id = id;
-        this.cpf = cpf;
-        this.address = address;
-        this.phone = phone;
-        this.person = person;
-    }
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getCpf() {
-        return cpf;
-    }
-
-    public void setCpf(String cpf) {
-        this.cpf = cpf;
-    }
-
-    public String getAddress() {
-        return address;
-    }
-
-    public void setAddress(String address) {
-        this.address = address;
-    }
-
-    public String getPhone() {
-        return phone;
-    }
-
-    public void setPhone(String phone) {
-        this.phone = phone;
-    }
-
-    public Person getPerson() {
-        return person;
-    }
-
-    public void setPerson(Person person) {
-        this.person = person;
-    }
-}
+public record ResidentRequest( String cpf, String address, String phone, Person person){}

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/request/UserRequest.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/input/request/UserRequest.java
@@ -1,17 +1,11 @@
 package br.com.washingtonDDS.acesso_api.adapter.input.request;
-import br.com.washingtonDDS.acesso_api.core.domain.model.Person;
-import lombok.*;
 
-@NoArgsConstructor
-@AllArgsConstructor
-@Getter
-@Setter
-public class UserRequest {
-    private Long id;
-    private String email;
-    private String password;
-    private Boolean administrator;
-    private Person person;
+import br.com.washingtonDDS.acesso_api.core.domain.model.Person;
+
+public record UserRequest (String email,
+                          String password,
+                          Boolean administrator, Person person
+                          ) {
 
 }
 

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/entity/PersonEntity.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/entity/PersonEntity.java
@@ -14,11 +14,11 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 @Setter
+
 @Table(name = "person")
 public class PersonEntity {
     @Id
     @GeneratedValue
     private Long id;
-
     private String name;
 }

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/entity/ResidentEntity.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/entity/ResidentEntity.java
@@ -1,10 +1,8 @@
 package br.com.washingtonDDS.acesso_api.adapter.output.entity;
 
 import br.com.washingtonDDS.acesso_api.core.domain.model.Person;
+import jakarta.persistence.*;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,6 +23,9 @@ public class ResidentEntity {
     private String cpf;
     private String address;
     private String phone;
-    private Person person;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "person_id")
+    private PersonEntity person;
 
 }

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/entity/UserEntity.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/entity/UserEntity.java
@@ -2,6 +2,7 @@ package br.com.washingtonDDS.acesso_api.adapter.output.entity;
 
 import br.com.washingtonDDS.acesso_api.core.domain.model.Person;
 import jakarta.persistence.*;
+import jakarta.persistence.Entity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,7 +22,8 @@ public class UserEntity {
     private String email;
     private String password;
     private Boolean administrator;
+
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "person_id")
-    private Person person;
+    private PersonEntity person;
 }

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/repositories/PersonRepositoryOutput.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/repositories/PersonRepositoryOutput.java
@@ -6,12 +6,12 @@ import br.com.washingtonDDS.acesso_api.core.domain.model.Person;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PersonRepositoryImpl {
+public class PersonRepositoryOutput {
 
     private final PersonRepository personRepository;
     private final PersonMapper personMapper;
 
-    public PersonRepositoryImpl(PersonRepository personRepository, PersonMapper personMapper) {
+    public PersonRepositoryOutput(PersonRepository personRepository, PersonMapper personMapper) {
         this.personRepository = personRepository;
         this.personMapper = personMapper;
     }

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/repositories/ResidentRepositoryOutput.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/repositories/ResidentRepositoryOutput.java
@@ -6,22 +6,24 @@ import br.com.washingtonDDS.acesso_api.adapter.output.entity.PersonEntity;
 import br.com.washingtonDDS.acesso_api.adapter.output.entity.ResidentEntity;
 import br.com.washingtonDDS.acesso_api.core.domain.model.Resident;
 import br.com.washingtonDDS.acesso_api.port.output.ResidentOutputPort;
+
 import org.springframework.stereotype.Component;
 
 @Component
-public class ResidentRepositoryImpl implements ResidentOutputPort {
+public class ResidentRepositoryOutput implements ResidentOutputPort {
 
     private final ResidentRepository residentRepository;
 
-    private final PersonRepositoryImpl personRepositoryImpl;
+    private final PersonRepository personRepository;
+
 
     private final ResidentMapper residentMapper;
 
     private final PersonMapper personMapper;
 
-    public ResidentRepositoryImpl(ResidentRepository residentRepository, PersonRepositoryImpl personRepositoryImpl, ResidentMapper residentMapper, PersonMapper personMapper) {
+    public ResidentRepositoryOutput(ResidentRepository residentRepository, PersonRepository personRepository, ResidentMapper residentMapper, PersonMapper personMapper) {
         this.residentRepository = residentRepository;
-        this.personRepositoryImpl = personRepositoryImpl;
+        this.personRepository = personRepository;
         this.residentMapper = residentMapper;
         this.personMapper = personMapper;
     }
@@ -31,8 +33,9 @@ public class ResidentRepositoryImpl implements ResidentOutputPort {
     public Resident save(Resident resident) {
         ResidentEntity residentEntity = residentMapper.toEntityResident(resident);
 
-        PersonEntity savedPersonEntity = personRepositoryImpl.savePerson(resident.getPerson());
-        residentEntity.setPerson(personMapper.toDomainPerson(savedPersonEntity));
+        PersonEntity savedPersonEntity = personMapper.toEntityPerson(resident.getPerson());
+        savedPersonEntity = personRepository.save(savedPersonEntity);
+        residentEntity.setPerson(savedPersonEntity);
 
         ResidentEntity newResident = residentRepository.save(residentEntity);
         return residentMapper.toDomainResidentEntity(newResident);
@@ -40,6 +43,7 @@ public class ResidentRepositoryImpl implements ResidentOutputPort {
 
     @Override
     public Resident getByCpf(String cpf) {
-        return null;
+        ResidentEntity residentByCpf = residentRepository.findByCpf(cpf);
+        return residentMapper.toDomainResidentEntity(residentByCpf);
     }
 }

--- a/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/repositories/UserRepositotyOutput.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/adapter/output/repositories/UserRepositotyOutput.java
@@ -9,19 +9,18 @@ import br.com.washingtonDDS.acesso_api.port.output.UserOutputPort;
 import org.springframework.stereotype.Component;
 
 @Component
-
-public class UserRepositotyImpl implements UserOutputPort {
+public class UserRepositotyOutput implements UserOutputPort {
     private final UserRepository  userRepository;
 
-    private final PersonRepositoryImpl personRepositoryImpl;
+    private final PersonRepository personRepository;
 
     private final UserMapper userMapper;
 
     private final PersonMapper personMapper;
 
-    public UserRepositotyImpl(UserRepository userRepository, PersonRepositoryImpl personRepositoryImpl, UserMapper userMapper, PersonMapper personMapper) {
+    public UserRepositotyOutput(UserRepository userRepository, PersonRepository personRepository, UserMapper userMapper, PersonMapper personMapper) {
         this.userRepository = userRepository;
-        this.personRepositoryImpl = personRepositoryImpl;
+        this.personRepository = personRepository;
         this.userMapper = userMapper;
         this.personMapper = personMapper;
     }
@@ -30,8 +29,9 @@ public class UserRepositotyImpl implements UserOutputPort {
     public User save(User user) {
         UserEntity userEntity = userMapper.toEntity(user);
 
-        PersonEntity savedPerson = personRepositoryImpl.savePerson(user.getPerson());
-        userEntity.setPerson(personMapper.toDomainPerson(savedPerson));
+        PersonEntity savedPerson = personMapper.toEntityPerson(user.getPerson());
+        savedPerson = personRepository.save(savedPerson);
+        userEntity.setPerson(savedPerson);
 
         UserEntity newUser = userRepository.save(userEntity);
         return userMapper.toDomainEntity(newUser);

--- a/src/main/java/br/com/washingtonDDS/acesso_api/core/usecase/ResidentUseCase.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/core/usecase/ResidentUseCase.java
@@ -13,8 +13,11 @@ public class ResidentUseCase implements ResidentInputPort {
     }
 
     @Override
-    public Resident create(Resident Resident) {
-
-        return residentOutputPort.save(Resident);
+    public Resident create(Resident resident) {
+        Resident  residentExist = residentOutputPort.getByCpf(resident.getCpf());
+        if (residentExist != null) {
+            throw new IllegalArgumentException("Resident with CPF " + resident.getCpf() + " already exists.");
+        }
+        return residentOutputPort.save(resident);
     }
 }

--- a/src/main/java/br/com/washingtonDDS/acesso_api/infrastructure/BeansConfig.java
+++ b/src/main/java/br/com/washingtonDDS/acesso_api/infrastructure/BeansConfig.java
@@ -1,6 +1,8 @@
 package br.com.washingtonDDS.acesso_api.infrastructure;
 
 import br.com.washingtonDDS.acesso_api.adapter.input.mapper.UserMapper;
+import br.com.washingtonDDS.acesso_api.adapter.output.entity.PersonEntity;
+import br.com.washingtonDDS.acesso_api.core.domain.model.Person;
 import br.com.washingtonDDS.acesso_api.core.usecase.ResidentUseCase;
 import br.com.washingtonDDS.acesso_api.core.usecase.UserUseCase;
 import br.com.washingtonDDS.acesso_api.port.output.ResidentOutputPort;
@@ -11,14 +13,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class BeansConfig {
 
-
     @Bean
-    public UserUseCase userUseCaseimpl(UserOutputPort userOutputPort){
+    public UserUseCase userUseCase(UserOutputPort userOutputPort){
         return new UserUseCase(userOutputPort);
     }
 
     @Bean
-    public ResidentUseCase residentUseCaseimpl(ResidentOutputPort residentOutputPort){
+    public ResidentUseCase residentUseCase(ResidentOutputPort residentOutputPort){
         return new ResidentUseCase(residentOutputPort);
     }
 }


### PR DESCRIPTION
…idade

Resolve o erro "Entity must not be null" que ocorria ao salvar entidades devido ao mapeamento incompleto entre DTOs de request e modelos de domínio.